### PR TITLE
Disable rotations

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         tools:targetApi="31" >
         <activity
             android:name=".MainActivity"
+            android:screenOrientation="portrait"
             android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Quick fix (v podstate rieši len rotácie)
android:screenOrientation="portrait"

Ďalšie problémy popísané v :
https://stackoverflow.com/questions/13647903/what-is-the-advantage-of-letting-an-activity-be-destroyed-on-rotation

